### PR TITLE
Fix param name in example (+formatting)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,22 @@ In case key doesn't exist in SSM it will upload file to SSM.
 
 Tool uses standard AWS profile mechanism - it should fallback to server role in case no profile / credential variables are provided.
 
+## Usage
+
+```text
+Usage of ssm-sync:
+  -file string
+        File path on disk
+  -kmsKeyAlias string
+        KMS key alias name (would use alias/<name> in KMS)
+  -region string
+        AWS Region (default "eu-west-1")
+  -ssm string
+        SSM Key name
+  -verbose
+        Enable verbose output
+```
+
 ## Example usage
 
-ssm-sync -ssm ${ENVIRONMENT}/ssh/${APPLICATION}/${KEY_NAME} -file ${KEY_PATH}/${KEY_NAME} -env ${ENVIRONMENT}
+`ssm-sync -ssm ${ENVIRONMENT}/ssh/${APPLICATION}/${KEY_NAME} -file ${KEY_PATH}/${KEY_NAME} -kmsKeyAlias ${ENVIRONMENT}`


### PR DESCRIPTION
Fix param name (env -> kmsKeyAlias) in example +formatting.
